### PR TITLE
Remove application tag from library

### DIFF
--- a/circularprogressview/src/main/AndroidManifest.xml
+++ b/circularprogressview/src/main/AndroidManifest.xml
@@ -1,8 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.rahatarmanahmed.cpv">
 
-    <application android:allowBackup="true" android:label="@string/app_name">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
Libraries should not use this tag, as any attributes inside it will conflict with projects that integrate the library and cause build errors.