### PR TITLE
Use animDuration config from XML when !indeterminate

### DIFF
--- a/circularprogressview/src/main/java/com/github/rahatarmanahmed/cpv/CircularProgressView.java
+++ b/circularprogressview/src/main/java/com/github/rahatarmanahmed/cpv/CircularProgressView.java
@@ -248,7 +248,7 @@ public class CircularProgressView extends View {
             if(progressAnimator != null && progressAnimator.isRunning())
                 progressAnimator.cancel();
             progressAnimator = ValueAnimator.ofFloat(actualProgress, currentProgress);
-            progressAnimator.setDuration(500);
+            progressAnimator.setDuration(animDuration);
             progressAnimator.setInterpolator(new LinearInterpolator());
             progressAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
                 @Override
@@ -295,7 +295,7 @@ public class CircularProgressView extends View {
             // The cool 360 swoop animation at the start of the animation
             startAngle = -90f;
             startAngleRotate = ValueAnimator.ofFloat(-90f, 270f);
-            startAngleRotate.setDuration(5000);
+            startAngleRotate.setDuration(animDuration);
             startAngleRotate.setInterpolator(new DecelerateInterpolator(2));
             startAngleRotate.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
                 @Override
@@ -309,7 +309,7 @@ public class CircularProgressView extends View {
             // The linear animation shown when progress is updated
             actualProgress = 0f;
             progressAnimator = ValueAnimator.ofFloat(actualProgress, currentProgress);
-            progressAnimator.setDuration(500);
+            progressAnimator.setDuration(animDuration);
             progressAnimator.setInterpolator(new LinearInterpolator());
             progressAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
                 @Override


### PR DESCRIPTION
Hi,
my proposal is to use animDuration from XML configuration also when the progress bar is !indeterminate, this way the developer can choose the animation also when s/he changes progress by code.
The code is not tested, edited directly here on github.

BR, Francesco