### PR TITLE
Added optional background with adjustable color and thickness

### DIFF
--- a/circularprogressview/src/main/res/values/attrs.xml
+++ b/circularprogressview/src/main/res/values/attrs.xml
@@ -6,7 +6,9 @@
         <attr name="cpv_animSwoopDuration" format="integer" />
         <attr name="cpv_animSyncDuration" format="integer" />
         <attr name="cpv_color" format="color"/>
+        <attr name="cpv_bgColor" format="color"/>
         <attr name="cpv_thickness" format="dimension"/>
+        <attr name="cpv_bgThickness" format="dimension"/>
         <attr name="cpv_indeterminate" format="boolean" />
         <attr name="cpv_animAutostart" format="boolean" />
         <attr name="cpv_animSteps" format="integer" />

--- a/circularprogressview/src/main/res/values/values.xml
+++ b/circularprogressview/src/main/res/values/values.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="cpv_default_color">#2196F3</color>
+    <color name="cpv_default_bg_color">#AAA</color>
     <dimen name="cpv_default_thickness">4dp</dimen>
+    <dimen name="cpv_default_bg_thickness">0dp</dimen>
     <integer name="cpv_default_progress">0</integer>
     <integer name="cpv_default_max_progress">100</integer>
     <bool name="cpv_default_is_indeterminate">false</bool>


### PR DESCRIPTION
I think displaying a background on (especially determinate) progress views is quite a common thing. So I've gone ahead and added the option to draw such a background circle. Color and thickness are adjustable as well.