### PR TITLE
Fix animation reset on unchanged isIndeterminate

### DIFF
--- a/circularprogressview/src/main/java/com/github/rahatarmanahmed/cpv/CircularProgressView.java
+++ b/circularprogressview/src/main/java/com/github/rahatarmanahmed/cpv/CircularProgressView.java
@@ -188,7 +188,7 @@ public class CircularProgressView extends View {
      */
     public void setIndeterminate(boolean isIndeterminate) {
         boolean old = this.isIndeterminate;
-        boolean reset = this.isIndeterminate == isIndeterminate;
+        boolean reset = this.isIndeterminate != isIndeterminate;
         this.isIndeterminate = isIndeterminate;
         if (reset)
             resetAnimation();


### PR DESCRIPTION
The reset check was inverted, so when you called `setIndeterminate(true)` (or false) multiple times on the view, it would reset the animation.